### PR TITLE
rework build to rely on nodeenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The snap version consists of the zigbee2mqtt release tag and an additional ascen
 Make sure you have snapd installed on your system. See [Installing snapd](https://snapcraft.io/docs/installing-snapd) for a list of distributions with and without snap pre-installed, including installation instructions for those that have not.
 
 ```bash
-$ snap install zigbee2mqtt
+$ snap install janlochi-zigbee2mqtt
 ```
 
 ### Setup
@@ -35,7 +35,7 @@ $ snap connect janlochi-zigbee2mqtt:serial-port core:usb20-serial # or snapd:usb
 
 ### Configuration
 
-The `configuration.yaml` is located in `/var/snap/zigbee2mqtt/current` and initially populated with a default configuration suitable for the snap.
+The `configuration.yaml` is located in `/var/snap/janlochi-zigbee2mqtt/current` and initially populated with a default configuration suitable for the snap.
 
 Consider using `/dev/serial/by-id/....` instead of `/dev/ttyUSB0`.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ architectures:
 
 apps:
   zigbee2mqtt:
-    command: bin/npm start --prefix $SNAP/lib/node_modules/zigbee2mqtt
+    command: bin/npm start --prefix $SNAP/app
     daemon: simple
     restart-condition: on-failure
     environment:
@@ -48,6 +48,7 @@ parts:
       - build-essential
     stage-packages:
       - libatomic1
+      - musl
     override-build: |
       # Fix some unbound variable errors from activate script (TODO: redundant?)
       set +u
@@ -71,25 +72,14 @@ parts:
       
       # copy source
       mkdir -p $SNAPCRAFT_PART_INSTALL/app
-      
+      cp -R ./* $SNAPCRAFT_PART_INSTALL/app/
     prime:
       # remove snap irrelevant scripts
-      - -update.sh
-      - -scripts/zigbee2socat_installer.sh
-      - -scripts/install.sh
+      - -app/update.sh
       # remove directories irrelevant for the snap
-      - -docker/
-      - -data/
-      - -include
-      - -share
-      # remove misc build and config files
-      - -*npm-shrinkwrap.json
-      - -azure-pipelines.yaml
-      - -yarn.lock
-      # remove nodejs infos
-      - -CHANGELOG.md
-      - -LICENSE
-      - -README.md
+      - -app/docker/
+      - -app/data/
+      - -app/test/
 
   default-config:
     # custom default config is shipped for the snap version

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,17 +50,11 @@ parts:
       - libatomic1
       - musl
     override-build: |
-      # Fix some unbound variable errors from activate script (TODO: redundant?)
-      set +u
-      #export _OLD_NODE_VIRTUAL_PATH=""
-      #export ZSH_VERSION=""
-      #export _OLD_NODE_VIRTUAL_PS1=""
-      #export NODE_PATH=""
-      #export NPM_CONFIG_PREFIX=""
-      
+      set +u # Fix some unbound variable errors from activate script
+
       craftctl default
       source $SNAPCRAFT_PART_INSTALL/bin/activate
-      nodeenv -p -n 16.15.0
+      nodeenv -p -n 18.14.2 
       deactivate
       source $SNAPCRAFT_PART_INSTALL/bin/activate
       
@@ -69,6 +63,9 @@ parts:
       
       # Install zigbee2mqtt deps:
       npm ci
+      
+      # Build zigbee2mqtt
+      npm run build
       
       # copy source
       mkdir -p $SNAPCRAFT_PART_INSTALL/app

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
 license: MIT
 icon: snap/gui/logo.png
 
-base: core20
+base: core22
 grade: stable
 confinement: strict
 adopt-info: set-version
@@ -33,25 +33,45 @@ apps:
 
 parts:
   zigbee2mqtt:
-    after: [nodejs]
-    plugin: npm
-    npm-node-version: '14.18.1'
+    plugin: python
     source: https://github.com/Koenkk/zigbee2mqtt
     source-type: git
-    source-tag: '1.21.2'
+    source-tag: '1.30.1'
     override-pull: |
-      snapcraftctl pull      
+      craftctl default      
       Z2M_GIT_TAG="$(git describe --tags --abbrev=0)"
       echo Git tag of zigbee2mqtt is ${Z2M_GIT_TAG}
       echo "export Z2M_GIT_TAG=${Z2M_GIT_TAG}" > /tmp/z2m-git-tag
+    python-packages: [pip, setuptools, wheel, nodeenv]
     build-packages:
       - gcc
       - build-essential
     stage-packages:
       - libatomic1
     override-build: |
-      npm config set unsafe-perm true
-      snapcraftctl build
+      # Fix some unbound variable errors from activate script (TODO: redundant?)
+      set +u
+      #export _OLD_NODE_VIRTUAL_PATH=""
+      #export ZSH_VERSION=""
+      #export _OLD_NODE_VIRTUAL_PS1=""
+      #export NODE_PATH=""
+      #export NPM_CONFIG_PREFIX=""
+      
+      craftctl default
+      source $SNAPCRAFT_PART_INSTALL/bin/activate
+      nodeenv -p -n 16.15.0
+      deactivate
+      source $SNAPCRAFT_PART_INSTALL/bin/activate
+      
+      # NPM is now ready
+      echo "NODE_PATH is: ${NODE_PATH}"
+      
+      # Install zigbee2mqtt deps:
+      npm ci
+      
+      # copy source
+      mkdir -p $SNAPCRAFT_PART_INSTALL/app
+      
     prime:
       # remove snap irrelevant scripts
       - -update.sh
@@ -70,22 +90,6 @@ parts:
       - -CHANGELOG.md
       - -LICENSE
       - -README.md
-   
-  nodejs:
-    # TODO: shouldn't the npm plugin take care of this step?
-    plugin: dump
-    source:
-    - on amd64: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-x64.tar.gz
-    - on arm64: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-arm64.tar.gz
-    - on armhf: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-armv7l.tar.gz
-    organize:
-      # move node.js specific docs to dedicated folder
-      '*.md' : nodejs/
-      LICENSE : nodejs/
-    prime:
-      # remove directories irrelevant for the snap
-      - -include
-      - -share
 
   default-config:
     # custom default config is shipped for the snap version


### PR DESCRIPTION
- uses the Python package nodeenv to get required node stuff
- cleanup readme
- bump zigbee2mqtt to 1.30.1